### PR TITLE
Integrate Supabase auth flow

### DIFF
--- a/src/pages/login/components/LoginForm.jsx
+++ b/src/pages/login/components/LoginForm.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../contexts/AuthContext';
 import Button from '../../../components/ui/Button';
 import Input from '../../../components/ui/Input';
 import Icon from '../../../components/AppIcon';
 
 const LoginForm = () => {
   const navigate = useNavigate();
+  const { signIn } = useAuth();
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -14,12 +16,6 @@ const LoginForm = () => {
   const [errors, setErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
 
-  // Mock credentials for different user roles
-  const mockCredentials = {
-    learner: { email: 'learner@sonsprophets.com', password: 'learner123' },
-    coach: { email: 'coach@sonsprophets.com', password: 'coach123' },
-    admin: { email: 'admin@sonsprophets.com', password: 'admin123' }
-  };
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -66,45 +62,28 @@ const LoginForm = () => {
     setIsLoading(true);
 
     try {
-      // Simulate API call delay
-      await new Promise(resolve => setTimeout(resolve, 1500));
+      const result = await signIn(formData.email, formData.password);
 
-      // Check credentials and determine user role
-      let userRole = null;
-      let isValidCredentials = false;
-
-      Object.entries(mockCredentials).forEach(([role, credentials]) => {
-        if (formData.email === credentials.email && formData.password === credentials.password) {
-          userRole = role;
-          isValidCredentials = true;
-        }
-      });
-
-      if (isValidCredentials) {
-        // Store user session (in real app, this would be handled by auth context)
-        localStorage.setItem('userRole', userRole);
-        localStorage.setItem('userEmail', formData.email);
-        localStorage.setItem('isAuthenticated', 'true');
-        
-        if (formData.rememberMe) {
-          localStorage.setItem('rememberMe', 'true');
-        }
-
-        // Navigate to appropriate dashboard based on role
-        switch (userRole) {
-          case 'learner': navigate('/learner-dashboard');
-            break;
-          case 'coach': navigate('/coach-dashboard');
-            break;
-          case 'admin': navigate('/admin-content-management');
-            break;
-          default:
-            navigate('/learner-dashboard');
-        }
-      } else {
+      if (!result?.success) {
         setErrors({
-          general: 'Invalid email or password. Please check your credentials and try again.'
+          general: result?.error || 'Invalid email or password. Please try again.'
         });
+        return;
+      }
+
+      const metadata = result.data?.user?.user_metadata ||
+        result.data?.session?.user?.user_metadata || {};
+      const role = metadata.role || 'learner';
+
+      switch (role) {
+        case 'coach':
+          navigate('/coach-dashboard');
+          break;
+        case 'admin':
+          navigate('/admin-content-management');
+          break;
+        default:
+          navigate('/learner-dashboard');
       }
     } catch (error) {
       setErrors({
@@ -217,13 +196,13 @@ const LoginForm = () => {
         {isLoading ? 'Signing In...' : 'Sign In'}
       </Button>
 
-      {/* Mock Credentials Helper */}
+      {/* Demo Credentials Helper */}
       <div className="mt-6 p-4 bg-accent-50 border border-accent-200 rounded-lg">
         <p className="text-xs font-caption text-accent-700 mb-2 font-body-semibold">Demo Credentials:</p>
         <div className="space-y-1 text-xs font-data">
-          <p className="text-accent-600">Learner: learner@sonsprophets.com / learner123</p>
-          <p className="text-accent-600">Coach: coach@sonsprophets.com / coach123</p>
-          <p className="text-accent-600">Admin: admin@sonsprophets.com / admin123</p>
+          <p className="text-accent-600">Member: member.john@sonsprophets.org / password123</p>
+          <p className="text-accent-600">Coach: coach.david@sonsprophets.org / password123</p>
+          <p className="text-accent-600">Admin: admin@sonsprophets.org / password123</p>
         </div>
       </div>
     </form>

--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
 import LoginHeader from './components/LoginHeader';
 import LoginForm from './components/LoginForm';
 import SocialLogin from './components/SocialLogin';
@@ -7,26 +8,22 @@ import LoginFooter from './components/LoginFooter';
 
 const Login = () => {
   const navigate = useNavigate();
+  const { user, userProfile, loading } = useAuth();
 
   useEffect(() => {
-    // Check if user is already authenticated
-    const isAuthenticated = localStorage.getItem('isAuthenticated');
-    const userRole = localStorage.getItem('userRole');
-
-    if (isAuthenticated === 'true' && userRole) {
-      // Redirect to appropriate dashboard based on role
-      switch (userRole) {
-        case 'learner': navigate('/learner-dashboard');
+    if (!loading && user && userProfile) {
+      switch (userProfile.role) {
+        case 'coach':
+          navigate('/coach-dashboard');
           break;
-        case 'coach': navigate('/coach-dashboard');
-          break;
-        case 'admin': navigate('/admin-content-management');
+        case 'admin':
+          navigate('/admin-content-management');
           break;
         default:
           navigate('/learner-dashboard');
       }
     }
-  }, [navigate]);
+  }, [user, userProfile, loading, navigate]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary-50 via-background to-accent-50">

--- a/src/pages/register/index.jsx
+++ b/src/pages/register/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
 import Icon from '../../components/AppIcon';
 import Button from '../../components/ui/Button';
 import ProgressIndicator from './components/ProgressIndicator';
@@ -12,6 +13,7 @@ import { safeGet, safeObjectEntries } from '../../utils/safeObjectUtils';
 
 const Register = () => {
   const navigate = useNavigate();
+  const { signUp } = useAuth();
   const [currentStep, setCurrentStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [registrationComplete, setRegistrationComplete] = useState(false);
@@ -136,7 +138,7 @@ const Register = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+
     if (!validateStep(currentStep) || !validateTermsAndPrivacy()) {
       return;
     }
@@ -144,13 +146,17 @@ const Register = () => {
     setIsSubmitting(true);
 
     try {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      // Mock registration success
-      console.log('Registration data:', formData);
-      setRegistrationComplete(true);
-      
+      const result = await signUp(formData.email, formData.password, {
+        full_name: formData.fullName,
+        role: formData.role || 'member',
+        plan: 'free'
+      });
+
+      if (!result?.success) {
+        setErrors({ submit: result?.error || 'Registration failed. Please try again.' });
+      } else {
+        setRegistrationComplete(true);
+      }
     } catch (error) {
       console.error('Registration failed:', error);
       setErrors({ submit: 'Registration failed. Please try again.' });


### PR DESCRIPTION
## Summary
- enable redirect on login based on Supabase profile
- hook login form into Supabase sign in
- update demo credentials to seeded accounts
- connect registration form to Supabase sign up

## Testing
- `npm test` *(fails: Failed to load PostCSS config)*

------
https://chatgpt.com/codex/tasks/task_e_687960550a1483259a12f7102f9a6b3e